### PR TITLE
🔒 Security fix: Add webhook authentication to doPost

### DIFF
--- a/router.js
+++ b/router.js
@@ -4,6 +4,14 @@
  * Postリクエストを処理する
  */
 function doPost(e) {
+  // Slackのトークン検証
+  const expectedToken = typeof PropertiesService !== 'undefined' ? PropertiesService.getScriptProperties().getProperty('SLACK_VERIFICATION_TOKEN') : null;
+  if (!expectedToken || !e || !e.parameter || e.parameter.token !== expectedToken) {
+    return typeof ContentService !== 'undefined'
+      ? ContentService.createTextOutput("Invalid token").setMimeType(ContentService.MimeType.TEXT)
+      : { status: 403, message: "Invalid token" };
+  }
+
   // Slackからのスラッシュコマンドは 'parameter' に入ってきます
   const params = e.parameter;
   // スラッシュコマンドのテキスト部分を取得 (例: "owner/repo bug fix")

--- a/router.js
+++ b/router.js
@@ -5,11 +5,9 @@
  */
 function doPost(e) {
   // Slackのトークン検証
-  const expectedToken = typeof PropertiesService !== 'undefined' ? PropertiesService.getScriptProperties().getProperty('SLACK_VERIFICATION_TOKEN') : null;
+  const expectedToken = PropertiesService.getScriptProperties().getProperty('SLACK_VERIFICATION_TOKEN');
   if (!expectedToken || !e || !e.parameter || e.parameter.token !== expectedToken) {
-    return typeof ContentService !== 'undefined'
-      ? ContentService.createTextOutput("Invalid token").setMimeType(ContentService.MimeType.TEXT)
-      : { status: 403, message: "Invalid token" };
+    return ContentService.createTextOutput("Invalid token").setMimeType(ContentService.MimeType.TEXT);
   }
 
   // Slackからのスラッシュコマンドは 'parameter' に入ってきます


### PR DESCRIPTION
🎯 **What:** The `doPost` function in `router.js`, which handles Slack webhooks, was missing authentication. It allowed any incoming POST request to be processed.
⚠️ **Risk:** Without authentication, an attacker could spoof requests from Slack, potentially triggering actions like starting Jules jobs or retrieving internal data, leading to unauthorized operations or data disclosure.
🛡️ **Solution:** Added a check to verify that `e.parameter.token` matches `SLACK_VERIFICATION_TOKEN` configured in Google Apps Script `PropertiesService`. If the token is invalid or missing, it now returns an error message ("Invalid token"), preventing unauthorized access.

---
*PR created automatically by Jules for task [5737195938192361431](https://jules.google.com/task/5737195938192361431) started by @kurousa*