### PR TITLE
🧪 Add lightweight unit tests for doPost and Slack interactions

### DIFF
--- a/command.js
+++ b/command.js
@@ -17,9 +17,7 @@ function usage() {
     `・一覧: \`${COMMANDS["list"]}\``
   ].join("\n");
 
-  return ContentService
-    .createTextOutput(message)
-    .setMimeType(ContentService.MimeType.TEXT);
+  return createTextResponse(message);
 }
 
 /**
@@ -44,9 +42,7 @@ function getJulesJobList() {
   }
 
   if (!sessions || sessions.length === 0) {
-      return ContentService
-        .createTextOutput("現在実行中のタスクはありません。")
-        .setMimeType(ContentService.MimeType.TEXT);
+      return createTextResponse("現在実行中のタスクはありません。");
   }
 
   let listMessage = isFromCache 
@@ -61,10 +57,10 @@ function getJulesJobList() {
     const sessionUrl = `https://jules.google.com/session/${sessionId}`;
     listMessage += `${i + 1}. *${repo}*\n   ${statusEmoji} ${title}\n   🔗 ${sessionUrl}\n`;
   });
-  Logger.log(`listMessage: \n ${listMessage}`);
-  return ContentService
-    .createTextOutput(listMessage)
-    .setMimeType(ContentService.MimeType.TEXT);      
+  if (typeof Logger !== 'undefined') {
+    Logger.log(`listMessage: \n ${listMessage}`);
+  }
+  return createTextResponse(listMessage);
 }
 
 /**
@@ -81,14 +77,10 @@ function startTask(text) {
     const julesResponse = createJulesSession(repo, prompt);
     saveActiveSession(julesResponse, repo);
     
-    return ContentService
-      .createTextOutput(`🚀 Julesがタスクを開始しました！\n📦 Repo: ${repo}\n\n進行状況は \`/jules list\` で確認できます。`)
-      .setMimeType(ContentService.MimeType.TEXT);
+    return createTextResponse(`🚀 Julesがタスクを開始しました！\n📦 Repo: ${repo}\n\n進行状況は \`/jules list\` で確認できます。`);
 
   } catch (err) {
-      return ContentService
-        .createTextOutput("Jules API連携エラー: " + err.toString())
-        .setMimeType(ContentService.MimeType.TEXT);
+      return createTextResponse("Jules API連携エラー: " + err.toString());
   }
 }
 
@@ -121,4 +113,8 @@ function checkJulesStatusAndNotify() {
       });
     }
   });
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { usage, getJulesJobList, startTask, checkJulesStatusAndNotify };
 }

--- a/slack.js
+++ b/slack.js
@@ -1,17 +1,34 @@
 // Slackとの通信を処理するモジュール
 
-const SLACK_BOT_TOKEN = PropertiesService.getScriptProperties().getProperty('SLACK_BOT_TOKEN');
-const SLACK_CHANNEL_ID = PropertiesService.getScriptProperties().getProperty('SLACK_CHANNEL_ID');
+let SLACK_BOT_TOKEN;
+let SLACK_CHANNEL_ID;
+
+if (typeof PropertiesService !== 'undefined') {
+  SLACK_BOT_TOKEN = PropertiesService.getScriptProperties().getProperty('SLACK_BOT_TOKEN');
+  SLACK_CHANNEL_ID = PropertiesService.getScriptProperties().getProperty('SLACK_CHANNEL_ID');
+}
 
 function sendSlackNotification(message) {
   if (!SLACK_BOT_TOKEN || !SLACK_CHANNEL_ID) {
-    Logger.log('SlackトークンまたはチャンネルIDが設定されていません。');
+    if (typeof Logger !== 'undefined') {
+      Logger.log('SlackトークンまたはチャンネルIDが設定されていません。');
+    }
     return;
   }
   
-  UrlFetchApp.fetch('https://slack.com/api/chat.postMessage', {
-    method: 'post',
-    headers: { 'Authorization': `Bearer ${SLACK_BOT_TOKEN}`, 'Content-Type': 'application/json' },
-    payload: JSON.stringify({ channel: SLACK_CHANNEL_ID, text: message })
-  });
+  if (typeof UrlFetchApp !== 'undefined') {
+    UrlFetchApp.fetch('https://slack.com/api/chat.postMessage', {
+      method: 'post',
+      headers: { 'Authorization': `Bearer ${SLACK_BOT_TOKEN}`, 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ channel: SLACK_CHANNEL_ID, text: message })
+    });
+  }
+}
+
+function createTextResponse(message) {
+  return ContentService.createTextOutput(message).setMimeType(ContentService.MimeType.TEXT);
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { sendSlackNotification, createTextResponse };
 }

--- a/tests/command.test.js
+++ b/tests/command.test.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+const commandCode = fs.readFileSync(path.join(__dirname, '../command.js'), 'utf8');
+
+function setupContext() {
+  const context = vm.createContext({
+    createTextResponse: (msg) => `Mocked: ${msg}`,
+    fetchJulesSessions: () => {
+      if (context.apiError) throw new Error("API Error");
+      return context.mockSessions || [];
+    },
+    updateCache: () => { context.cacheUpdated = true; },
+    getActiveSessionsCache: () => context.mockCacheSessions || [],
+    console: { warn: () => { context.warnCalled = true; } },
+    getStatusEmoji: () => 'emoji',
+    createJulesSession: (repo, prompt) => {
+      if (context.apiError) throw new Error("API Error");
+      return { id: '123' };
+    },
+    saveActiveSession: (res, repo) => { context.savedSession = repo; },
+    callFirebase: () => {},
+    fetchLatestActivity: () => {},
+    sendSlackNotification: () => {},
+    module: {}
+  });
+  vm.runInContext(commandCode, context);
+  return context;
+}
+
+function runTests() {
+  let context;
+
+  // Test usage()
+  context = setupContext();
+  let result = context.usage();
+  assert.ok(result.includes("💡 使いかた:"));
+
+  // Test getJulesJobList() - empty
+  context = setupContext();
+  result = context.getJulesJobList();
+  assert.ok(result.includes("現在実行中のタスクはありません。"));
+
+  // Test getJulesJobList() - success
+  context = setupContext();
+  context.mockSessions = [{ name: 'session/123', state: 'RUNNING', title: 'Fix bug', sourceContext: { source: 'sources/github/owner/repo' } }];
+  result = context.getJulesJobList();
+  assert.strictEqual(context.cacheUpdated, true);
+  assert.ok(result.includes("📂 *Jules API セッション一覧:*"));
+  assert.ok(result.includes("owner/repo"));
+
+  // Test getJulesJobList() - cache fallback
+  context = setupContext();
+  context.apiError = true;
+  context.mockCacheSessions = [{ name: 'session/123', state: 'RUNNING', title: 'Fix bug', repo: 'owner/repo' }];
+  result = context.getJulesJobList();
+  assert.strictEqual(context.warnCalled, true);
+  assert.ok(result.includes("⚠️ *APIタイムアウトのためキャッシュを表示中:*"));
+
+  // Test startTask() - success
+  context = setupContext();
+  result = context.startTask("owner/repo fix this bug");
+  assert.strictEqual(context.savedSession, "owner/repo");
+  assert.ok(result.includes("🚀 Julesがタスクを開始しました！"));
+
+  // Test startTask() - error
+  context = setupContext();
+  context.apiError = true;
+  result = context.startTask("owner/repo fix this bug");
+  assert.ok(result.includes("Jules API連携エラー: Error: API Error"));
+}
+
+runTests();

--- a/tests/router.test.js
+++ b/tests/router.test.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+const routerCode = fs.readFileSync(path.join(__dirname, '../router.js'), 'utf8');
+
+function runTests() {
+  let calls = {};
+
+  const context = vm.createContext({
+    getJulesJobList: () => { calls.getJulesJobList = (calls.getJulesJobList || 0) + 1; return 'Mocked List'; },
+    usage: () => { calls.usage = (calls.usage || 0) + 1; return 'Mocked Usage'; },
+    startTask: (text) => {
+      calls.startTask = (calls.startTask || 0) + 1;
+      calls.startTaskArg = text;
+      return 'Mocked Start Task';
+    },
+    module: {}
+  });
+
+  vm.runInContext(routerCode, context);
+
+  // Test 1
+  calls = {};
+  let result = context.doPost({ parameter: { text: 'list' } });
+  assert.strictEqual(calls.getJulesJobList, 1);
+  assert.strictEqual(result, 'Mocked List');
+
+  // Test 2
+  calls = {};
+  result = context.doPost({ parameter: { text: 'LIST' } });
+  assert.strictEqual(calls.getJulesJobList, 1);
+
+  // Test 3
+  calls = {};
+  result = context.doPost({ parameter: { text: 'repo_only' } });
+  assert.strictEqual(calls.usage, 1);
+
+  // Test 4
+  calls = {};
+  result = context.doPost({ parameter: { text: '  ' } });
+  assert.strictEqual(calls.usage, 1);
+
+  // Test 5
+  calls = {};
+  result = context.doPost({ parameter: { text: ' repo prompt ' } });
+  assert.strictEqual(calls.startTask, 1);
+  assert.strictEqual(calls.startTaskArg, 'repo prompt');
+
+  // Test 6
+  calls = {};
+  result = context.doGet({});
+  assert.strictEqual(calls.usage, 1);
+}
+
+runTests();

--- a/tests/run_tests.js
+++ b/tests/run_tests.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const testFiles = fs.readdirSync(__dirname).filter(f => f.endsWith('.test.js'));
+let failed = false;
+
+testFiles.forEach(file => {
+  console.log(`Running ${file}...`);
+  try {
+    require(path.join(__dirname, file));
+    console.log(`✅ ${file} passed\n`);
+  } catch (err) {
+    console.error(`❌ ${file} failed:\n`, err);
+    failed = true;
+  }
+});
+
+if (failed) {
+  process.exit(1);
+} else {
+  console.log("All tests passed!");
+}

--- a/tests/slack.test.js
+++ b/tests/slack.test.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+const slackCode = fs.readFileSync(path.join(__dirname, '../slack.js'), 'utf8');
+
+function setupContext(token, channel) {
+  const context = vm.createContext({
+    Logger: { log: () => { context.logs = (context.logs || 0) + 1; } },
+    UrlFetchApp: { fetch: (url, opts) => { context.fetchOpts = opts; } },
+    PropertiesService: {
+      getScriptProperties: () => ({
+        getProperty: (key) => {
+          if (key === 'SLACK_BOT_TOKEN') return token;
+          if (key === 'SLACK_CHANNEL_ID') return channel;
+          return null;
+        }
+      })
+    },
+    ContentService: {
+      createTextOutput: (msg) => ({
+        setMimeType: (mime) => `Mocked: ${msg} [${mime}]`
+      }),
+      MimeType: { TEXT: 'TEXT_MIME' }
+    },
+    module: {}
+  });
+  vm.runInContext(slackCode, context);
+  return context;
+}
+
+function runTests() {
+  // Test 1: Missing Token
+  let context = setupContext(null, 'channel_id');
+  context.sendSlackNotification('Test message');
+  assert.strictEqual(context.logs, 1);
+  assert.strictEqual(context.fetchOpts, undefined);
+
+  // Test 2: Missing Channel
+  context = setupContext('token', null);
+  context.sendSlackNotification('Test message');
+  assert.strictEqual(context.logs, 1);
+  assert.strictEqual(context.fetchOpts, undefined);
+
+  // Test 3: Success
+  context = setupContext('token', 'channel_id');
+  context.sendSlackNotification('Test message');
+  assert.strictEqual(context.logs, undefined);
+  assert.strictEqual(context.fetchOpts.method, 'post');
+  assert.strictEqual(context.fetchOpts.headers.Authorization, 'Bearer token');
+
+  // Test 4: createTextResponse
+  const response = context.createTextResponse('Hello');
+  assert.strictEqual(response, 'Mocked: Hello [TEXT_MIME]');
+}
+
+runTests();


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The issue highlighted a missing set of tests for the `doPost` entry point inside `router.js` and Slack-related operations. We've introduced custom, lightweight testing setup running entirely in native Node.js (via the `assert` and `vm` modules) avoiding heavy dependencies or complex CI/CD environment requirements.

📊 **Coverage:** What scenarios are now tested
1. **router.js:** Tests cover the Slack payload text routing. Ensures requests with the parameter "list", empty texts, and repository-prompt queries resolve properly via the `doPost` function mappings (`getJulesJobList`, `usage`, `startTask`). Covers `doGet` mappings.
2. **slack.js:** Tests cover missing variables and standard paths, verifying that `sendSlackNotification` invokes `UrlFetchApp` and `createTextResponse` creates matching instances via the `ContentService.createTextOutput().setMimeType` structure.
3. **command.js:** Tested behavior of `usage()`, `getJulesJobList()`, and `startTask()` taking advantage of `createTextResponse`.

✨ **Result:** The improvement in test coverage
Tests can now be executed entirely offline without relying strictly on GAS triggers or `clasp` deploy feedback loops by running `node tests/run_tests.js`. High confidence established for webhook request behaviors.

---
*PR created automatically by Jules for task [8091879697431579826](https://jules.google.com/task/8091879697431579826) started by @kurousa*