### PR TITLE
🧪 Improve startTask tests and robustness

### DIFF
--- a/command.js
+++ b/command.js
@@ -66,9 +66,19 @@ function getJulesJobList() {
  * @input /jules task start [repo] [promt]
  */
 function startTask(text) {
-  const firstSpaceIndex = text.indexOf(' ');
-  const repo = text.substring(0, firstSpaceIndex);
-  const prompt = text.substring(firstSpaceIndex + 1);
+  const trimmedText = text.trim();
+  const firstSpaceIndex = trimmedText.indexOf(' ');
+
+  if (firstSpaceIndex === -1) {
+    return createTextResponse_("エラー: リポジトリ名とプロンプトをスペース区切りで入力してください。\n例: `owner/repo bug fix` ");
+  }
+
+  const repo = trimmedText.substring(0, firstSpaceIndex);
+  const prompt = trimmedText.substring(firstSpaceIndex + 1).trim();
+
+  if (!repo || !prompt) {
+    return createTextResponse_("エラー: リポジトリ名またはプロンプトが不足しています。");
+  }
 
   try {
     const julesResponse = createJulesSession(repo, prompt);

--- a/tests/command.test.js
+++ b/tests/command.test.js
@@ -8,6 +8,7 @@ const commandCode = fs.readFileSync(path.join(__dirname, '../command.js'), 'utf8
 function setupContext() {
   const context = vm.createContext({
     createTextResponse: (msg) => `Mocked: ${msg}`,
+    createTextResponse_: (msg) => `Mocked: ${msg}`,
     fetchJulesSessions: () => {
       if (context.apiError) throw new Error("API Error");
       return context.mockSessions || [];
@@ -70,6 +71,29 @@ function runTests() {
   context.apiError = true;
   result = context.startTask("owner/repo fix this bug");
   assert.ok(result.includes("Jules API連携エラー: Error: API Error"));
+
+  // Test startTask() - no space (edge case)
+  context = setupContext();
+  result = context.startTask("owner/repo");
+  assert.ok(result.includes("エラー: リポジトリ名とプロンプトをスペース区切りで入力してください。"));
+
+  // Test startTask() - leading space
+  context = setupContext();
+  result = context.startTask(" owner/repo prompt");
+  assert.strictEqual(context.savedSession, "owner/repo");
+  assert.ok(result.includes("🚀 Julesがタスクを開始しました！"));
+  assert.ok(result.includes("Repo: owner/repo"));
+
+  // Test startTask() - multiple spaces
+  context = setupContext();
+  result = context.startTask("owner/repo  prompt with spaces");
+  assert.strictEqual(context.savedSession, "owner/repo");
+  assert.ok(result.includes("Repo: owner/repo"));
+
+  // Test startTask() - empty prompt after repo
+  context = setupContext();
+  result = context.startTask("owner/repo  ");
+  assert.ok(result.includes("エラー: リポジトリ名とプロンプトをスペース区切りで入力してください。"));
 }
 
 runTests();


### PR DESCRIPTION
This PR improves the reliability and test coverage of the `startTask` function in `command.js`.

🎯 **What:** The testing gap addressed
- `startTask` was missing tests for edge cases like malformed input strings (missing spaces, leading/trailing whitespace, etc.).
- The existing test suite had a `ReferenceError` for `createTextResponse_`.

📊 **Coverage:** What scenarios are now tested
- Valid input (happy path).
- Input with no space (missing mandatory repo/prompt separation).
- Input with leading/trailing whitespace.
- Input with multiple spaces between arguments.
- Input with missing prompt.

✨ **Result:** The improvement in test coverage
- `startTask` is now more robust, correctly parsing inputs with varied whitespace and providing user-friendly error messages for malformed commands.
- The unit test suite for `command.js` now runs successfully without reference errors and covers more failure modes.

---
*PR created automatically by Jules for task [992613390312883082](https://jules.google.com/task/992613390312883082) started by @kurousa*